### PR TITLE
Get default signature from correct repo

### DIFF
--- a/R/commit.R
+++ b/R/commit.R
@@ -23,7 +23,7 @@ git_commit <- function(message, author = NULL, committer = NULL, repo = '.'){
   if(is.character(repo))
     repo <- git_open(repo)
   if(!length(author))
-    author <- git_signature_default()
+    author <- git_signature_default(repo)
   if(!length(committer))
     committer <- author
   stopifnot(is.character(message), length(message) == 1)

--- a/tests/testthat/test-commit.R
+++ b/tests/testthat/test-commit.R
@@ -50,3 +50,17 @@ test_that("creating a commit", {
   expect_equal(log$author[2], author)
   expect_equal(log$time[1], timestamp)
 })
+
+
+test_that("creating a commit in another directory without author works", {
+  path <- tempfile()
+  dir.create(path)
+  repo <- git_init(path)
+  writeLines("content", file.path(path, "file"))
+  git_add("file", repo = path)
+  git_commit("Added file", repo = repo)
+
+  log <- git_log(repo = repo)
+  sig <- git_signature_default(repo)
+  expect_equal(log$author, git_signature_info(sig)$author)
+})


### PR DESCRIPTION
We ran into this while swapping out some bits that shell out to git for `gert`.  If the signature is not provided and the repo is not the working directory, then the commit fails.  This PR gets the default signature from the intended repo.