### PR TITLE
Use a smaller example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ This is a basic example:
 
 ``` r
 library(gert)
-path <- file.path(tempdir(), "ggplot2")
-repo <- git_clone("https://github.com/hadley/ggplot2", path)
+path <- file.path(tempdir(), "gert")
+repo <- git_clone("https://github.com/r-lib/gert", path)
 print(repo)
 ```
 


### PR DESCRIPTION
The current README example uses `ggplot2`, which is one of the largest R package repos. 

Swap to a smaller repo to make it quicker for new users.