### PR TITLE
Fixes an issue when pushing a repo other than "."

### DIFF
--- a/R/fetch.R
+++ b/R/fetch.R
@@ -52,7 +52,7 @@ git_push <- function(remote = NULL, refspec = NULL, password = askpass,
   cred_cb <- make_cred_cb(password = password, verbose = verbose)
   .Call(R_git_remote_push, repo, remote, refspec, key_cb, cred_cb, verbose)
   if(isTRUE(is.na(info$upstream))){
-    git_branch_set_upstream(paste0(remote, "/", info$shorthand))
+    git_branch_set_upstream(paste0(remote, "/", info$shorthand), repo)
   }
   repo
 }


### PR DESCRIPTION
I was seeing the issue when doing something like the following, (working from `~/tmp` to push a repo `~/tmp/test`)

```r
setwd("~/tmp")
gert::git_push("origin", glue::glue("refs/heads/{branch}:refs/heads/{branch}", branch = "new"), verbose=TRUE, repo = "test/")
# Trying to authenticate with your GITHUB_PAT
# [status] refs/heads/styler: unchanged
# [new]     37774afb163318f9bd10 refs/remotes/origin/styler
# Error in git_open(repo) : 
#   libgit2 error in git_repository_open_ext: could not find repository from '/Users/rundel/tmp' (6)

traceback()
# 3: git_open(repo)
# 2: git_branch_set_upstream(paste0(remote, "/", info$shorthand))
# 1: gert::git_push("origin", glue::glue("refs/heads/{branch}:refs/heads/{branch}", 
#        branch = "styler"), verbose = TRUE, repo = "test/")
```