### PR TITLE
Support for clone --mirror and push --mirror

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gert
 Type: Package
 Title: Simple Git Client for R
-Version: 0.2
+Version: 0.2.0.9000
 Author: Jeroen Ooms
 Maintainer: Jeroen Ooms <jeroen@berkeley.edu>
 Description: Simple git client based on 'libgit2' with user-friendly authentication

--- a/R/fetch.R
+++ b/R/fetch.R
@@ -98,8 +98,8 @@ git_push <- function(remote = NULL, refspec = NULL, password = askpass,
 #' setwd(olddir)
 #' unlink(git_dir, recursive = TRUE)
 #' }
-git_clone <- function(url, path = NULL, branch = NULL, password = askpass,
-                      ssh_key = NULL, verbose = interactive()){
+git_clone <- function(url, path = NULL, branch = NULL, password = askpass, ssh_key = NULL,
+                      bare = FALSE, mirror = FALSE, verbose = interactive()){
   stopifnot(is.character(url))
   if(!length(path))
     path <- file.path(getwd(), basename(url))
@@ -110,7 +110,7 @@ git_clone <- function(url, path = NULL, branch = NULL, password = askpass,
   host <- url_to_host(url)
   key_cb <- make_key_cb(ssh_key, host = host, password = password)
   cred_cb <- make_cred_cb(password = password, verbose = verbose)
-  .Call(R_git_repository_clone, url, path, branch, key_cb, cred_cb, verbose)
+  .Call(R_git_repository_clone, url, path, branch, key_cb, cred_cb, bare, mirror, verbose)
 }
 
 #' @export

--- a/R/fetch.R
+++ b/R/fetch.R
@@ -52,7 +52,7 @@ git_push <- function(remote = NULL, refspec = NULL, password = askpass,
   cred_cb <- make_cred_cb(password = password, verbose = verbose)
   .Call(R_git_remote_push, repo, remote, refspec, key_cb, cred_cb, verbose)
   if(isTRUE(is.na(info$upstream))){
-    git_branch_set_upstream(paste0(remote, "/", info$shorthand))
+    git_branch_set_upstream(paste0(remote, "/", info$shorthand), repo)
   }
   repo
 }

--- a/R/fetch.R
+++ b/R/fetch.R
@@ -12,6 +12,10 @@
 #' @useDynLib gert R_git_remote_fetch
 #' @param remote name of a remote listed in [git_remote_list()]
 #' @param refspec string with mapping between remote and local refs
+#' @param mirror use the `--mirror` flag
+#' @param bare use the `--bare` flag
+#' @param force use the `--force` flag
+
 git_fetch <- function(remote = NULL, refspec = NULL, password = askpass,
                       ssh_key = NULL, verbose = interactive(), repo = '.'){
   repo <- git_open(repo)

--- a/R/repository.R
+++ b/R/repository.R
@@ -55,5 +55,11 @@ git_info <- function(repo = '.'){
 #' @export
 print.git_repo_ptr <- function(x, ...){
   info <- git_info(x)
-  cat(sprintf("<git repository>: %s[@%s]\n", normalizePath(info$path), info$shorthand))
+
+  type = "git repository"
+  if(info$bare){
+    type = paste(type, "(bare)")
+  }
+
+  cat(sprintf("<%s>: %s[@%s]\n", type, normalizePath(info$path), info$shorthand))
 }

--- a/man/fetch.Rd
+++ b/man/fetch.Rd
@@ -12,7 +12,8 @@ git_fetch(remote = NULL, refspec = NULL, password = askpass,
   ssh_key = NULL, verbose = interactive(), repo = ".")
 
 git_push(remote = NULL, refspec = NULL, password = askpass,
-  ssh_key = NULL, verbose = interactive(), repo = ".")
+  ssh_key = NULL, mirror = FALSE, force = FALSE,
+  verbose = interactive(), repo = ".")
 
 git_clone(url, path = NULL, branch = NULL, password = askpass,
   ssh_key = NULL, bare = FALSE, mirror = FALSE,

--- a/man/fetch.Rd
+++ b/man/fetch.Rd
@@ -38,6 +38,10 @@ look for keys in \code{ssh-agent} and \link[credentials:ssh_key_info]{credential
 \item{repo}{a path to an existing repository, or a \code{git_repository} object as
 returned by \link{git_open},  \link{git_init} or \link{git_clone}.}
 
+\item{mirror}{use the \code{--mirror} flag}
+
+\item{force}{use the \code{--force} flag}
+
 \item{url}{remote url. Typically starts with \code{https://github.com/} for public
 repositories, and \code{https://yourname@github.com/} or \code{git@github.com/} for
 private repos. You will be prompted for a password or pat when needed.}
@@ -46,6 +50,8 @@ private repos. You will be prompted for a password or pat when needed.}
 this must be a non-existing or empty directory.}
 
 \item{branch}{name of branch to check out locally}
+
+\item{bare}{use the \code{--bare} flag}
 
 \item{...}{arguments passed to \link{git_fetch}}
 }

--- a/man/fetch.Rd
+++ b/man/fetch.Rd
@@ -15,7 +15,8 @@ git_push(remote = NULL, refspec = NULL, password = askpass,
   ssh_key = NULL, verbose = interactive(), repo = ".")
 
 git_clone(url, path = NULL, branch = NULL, password = askpass,
-  ssh_key = NULL, verbose = interactive())
+  ssh_key = NULL, bare = FALSE, mirror = FALSE,
+  verbose = interactive())
 
 git_pull(..., repo = ".")
 }

--- a/man/git_config.Rd
+++ b/man/git_config.Rd
@@ -3,8 +3,8 @@
 \name{git_config}
 \alias{git_config}
 \alias{libgit2_config}
-\alias{git_config_set}
 \alias{git_config_global}
+\alias{git_config_set}
 \alias{git_config_global_set}
 \title{Version info}
 \usage{
@@ -12,9 +12,9 @@ libgit2_config()
 
 git_config(repo = ".")
 
-git_config_set(name, value, repo = ".")
-
 git_config_global()
+
+git_config_set(name, value, repo = ".")
 
 git_config_global_set(name, value)
 }

--- a/src/init.c
+++ b/src/init.c
@@ -22,7 +22,7 @@ extern SEXP R_git_remote_list(SEXP);
 extern SEXP R_git_remote_push(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP R_git_remote_remove(SEXP, SEXP);
 extern SEXP R_git_repository_add(SEXP, SEXP, SEXP);
-extern SEXP R_git_repository_clone(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP R_git_repository_clone(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP R_git_repository_info(SEXP);
 extern SEXP R_git_repository_init(SEXP);
 extern SEXP R_git_repository_ls(SEXP);
@@ -58,7 +58,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"R_git_remote_push",        (DL_FUNC) &R_git_remote_push,        6},
   {"R_git_remote_remove",      (DL_FUNC) &R_git_remote_remove,      2},
   {"R_git_repository_add",     (DL_FUNC) &R_git_repository_add,     3},
-  {"R_git_repository_clone",   (DL_FUNC) &R_git_repository_clone,   6},
+  {"R_git_repository_clone",   (DL_FUNC) &R_git_repository_clone,   8},
   {"R_git_repository_info",    (DL_FUNC) &R_git_repository_info,    1},
   {"R_git_repository_init",    (DL_FUNC) &R_git_repository_init,    1},
   {"R_git_repository_ls",      (DL_FUNC) &R_git_repository_ls,      1},

--- a/src/init.c
+++ b/src/init.c
@@ -22,7 +22,7 @@ extern SEXP R_git_remote_list(SEXP);
 extern SEXP R_git_remote_push(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP R_git_remote_remove(SEXP, SEXP);
 extern SEXP R_git_repository_add(SEXP, SEXP, SEXP);
-extern SEXP R_git_repository_clone(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP R_git_repository_clone(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP R_git_repository_info(SEXP);
 extern SEXP R_git_repository_init(SEXP);
 extern SEXP R_git_repository_ls(SEXP);


### PR DESCRIPTION
This PR contains a possible implementation to support the above git functionality. I've tried to separate the three commits into the logical feature sets.

* The 1st commit includes support for bare repositories by `git_info` this includes the addition of a logical value `bare` in the list as well as a tweak to the print method to indicate a repo is bare. Additionally, since bare repo's don't have a working directory I've used the repository path instead. I haven't tested these changes extensively but they seem reasonably innocuous and it seems like libgit2does most of the heavy lifting in knowing what to do with a bare vs normal repo.

* 2nd commit includes support for mirror and bare cloning, the support remote call back function comes almost directly from the libgit2 docs. Default behavior stays the same so there shouldn't be any side effects.

* 3rd commit includes support for `push --mirror` and `push --force`, I couldn't find a huge amount of details on what exactly is supposed to happen with this process and my approach is to just push all the refs in the repo (excluding github pull refs). This may be the wrong approach but it seems to work with my limited testing. The force option just monkey's with the refspecs, it might be nicer to handle this some other way but this was an quick fix for the time being.

I'm happy to discuss possible alternative implementations.