### PR TITLE
Add remote argument to git_pull

### DIFF
--- a/man/git_fetch.Rd
+++ b/man/git_fetch.Rd
@@ -39,7 +39,7 @@ git_clone(
   verbose = interactive()
 )
 
-git_pull(rebase = FALSE, ..., repo = ".")
+git_pull(remote = NULL, rebase = FALSE, ..., repo = ".")
 }
 \arguments{
 \item{remote}{Optional. Name of a remote listed in \code{\link[=git_remote_list]{git_remote_list()}}. If


### PR DESCRIPTION
Proposed fix for #63.

I've checked it for the basic workflows that are equivalent to `git pull origin` and `git pull upstream` and things seem to be working. I think this only touches the `git_merge` branch and not the `git_rebase`, so checking the latter might be worthwhile.

Sanity checking my use of `remote` vs `upstream` as well as the use of `shorthand`, particularly for edge cases, is probably needed.
