### PR TITLE
Bump version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gert
 Title: Simple Git Client for R
-Version: 0.3.9001
+Version: 0.3.9002
 Authors@R: c(
     person("Jeroen", "Ooms", role = c("aut", "cre"), email = "jeroen@berkeley.edu",
       comment = c(ORCID = "0000-0002-4035-0289")),


### PR DESCRIPTION
Can we bump dev version in light of b3bc2acc506e725749c17e0f685c2501d4daa184 (tweaks re: remotes) and 1f2a19905cc6afa6c8ab683cfbc9d59e6dcb32c2 (setting tracking branch), so I can bump min version in usethis and then count on this?