### PR TITLE
Allow to specify remote in git_pull()

### DIFF
--- a/man/git_fetch.Rd
+++ b/man/git_fetch.Rd
@@ -40,7 +40,7 @@ git_clone(
   verbose = interactive()
 )
 
-git_pull(rebase = FALSE, ..., repo = ".")
+git_pull(remote = NULL, rebase = FALSE, ..., repo = ".")
 }
 \arguments{
 \item{remote}{Optional. Name of a remote listed in \code{\link[=git_remote_list]{git_remote_list()}}. If


### PR DESCRIPTION
Fixes #63, closes #64

@rundel I refactored your code a bit, does this look good? 

We deliberately pass down `remote` to `git_fetch()` even if it is `NULL` because in that case `git_fetch` will deal with it. 