### PR TITLE
DWIM all the ref arguments

### DIFF
--- a/src/merge.c
+++ b/src/merge.c
@@ -3,13 +3,12 @@
 
 /* I think this does exactly the same as GIT_RESET_MIXED */
 SEXP R_git_branch_set_target(SEXP ptr, SEXP ref){
-  git_object *revision = NULL;
   git_reference *head = NULL;
   git_reference *out_target = NULL;
   git_repository *repo = get_git_repository(ptr);
+  git_object *revision = resolve_refish(ref, repo);
   git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
   bail_if(git_repository_head(&head, repo), "git_repository_head");
-  bail_if(git_revparse_single(&revision, repo, CHAR(STRING_ELT(ref, 0))), "git_revparse_single");
   bail_if(git_checkout_tree(repo, revision, &opts), "git_checkout_tree");
   bail_if(git_reference_set_target(&out_target, head, git_object_id(revision), NULL), "git_reference_set_target");
   git_reference_free(out_target);
@@ -19,12 +18,10 @@ SEXP R_git_branch_set_target(SEXP ptr, SEXP ref){
 }
 
 SEXP R_git_merge_find_base(SEXP ptr, SEXP ref1, SEXP ref2){
-  git_object *t1 = NULL;
-  git_object *t2 = NULL;
   git_oid base = {{0}};
   git_repository *repo = get_git_repository(ptr);
-  bail_if(git_revparse_single(&t1, repo, CHAR(STRING_ELT(ref1, 0))), "git_revparse_single");
-  bail_if(git_revparse_single(&t2, repo, CHAR(STRING_ELT(ref2, 0))), "git_revparse_single");
+  git_object *t1 = resolve_refish(ref1, repo);
+  git_object *t2 = resolve_refish(ref2, repo);
   bail_if(git_merge_base(&base, repo, git_object_id(t1), git_object_id(t2)), "git_merge_base");
   git_object_free(t1);
   git_object_free(t2);

--- a/src/rebase.c
+++ b/src/rebase.c
@@ -118,10 +118,9 @@ SEXP R_git_cherry_pick(SEXP ptr, SEXP commit_id){
 
 SEXP R_git_ahead_behind(SEXP ptr, SEXP local, SEXP upstream){
   size_t ahead, behind;
-  git_object *rev_local = NULL, *rev_upstream = NULL;
   git_repository *repo = get_git_repository(ptr);
-  bail_if(git_revparse_single(&rev_local, repo, CHAR(STRING_ELT(local, 0))), "git_revparse_single");
-  bail_if(git_revparse_single(&rev_upstream, repo, CHAR(STRING_ELT(upstream, 0))), "git_revparse_single");
+  git_object *rev_local = resolve_refish(local, repo);
+  git_object *rev_upstream = resolve_refish(upstream, repo);
   bail_if(git_graph_ahead_behind(&ahead, &behind, repo,
                                  git_object_id(rev_local), git_object_id(rev_upstream)), "git_graph_ahead_behind");
   git_object_free(rev_local);

--- a/src/tag.c
+++ b/src/tag.c
@@ -24,12 +24,11 @@ SEXP R_git_tag_list(SEXP ptr, SEXP pattern){
 SEXP R_git_tag_create(SEXP ptr, SEXP name, SEXP message, SEXP ref){
   git_oid tag;
   git_signature *me = NULL;
-  git_object *revision = NULL;
   const char *cname = CHAR(STRING_ELT(name, 0));
   const char *cmsg = CHAR(STRING_ELT(message, 0));
   git_repository *repo = get_git_repository(ptr);
+  git_object *revision = resolve_refish(ref, repo);
   bail_if(git_signature_default(&me, repo), "git_signature_default");
-  bail_if(git_revparse_single(&revision, repo, CHAR(STRING_ELT(ref, 0))), "git_revparse_single");
   bail_if(git_tag_create(&tag, repo, cname, revision, me, cmsg, 0), "git_tag_create");
   git_signature_free(me);
   git_object_free(revision);

--- a/src/utils.c
+++ b/src/utils.c
@@ -27,6 +27,33 @@ void bail_if_null(void * ptr, const char * what){
     bail_if(-1, what);
 }
 
+git_object * resolve_refish(SEXP string, git_repository *repo){
+  if(!Rf_isString(string) || !Rf_length(string))
+    Rf_error("Reference is not a string");
+  const char *str = CHAR(STRING_ELT(string, 0));
+  git_reference *ref = NULL;
+  git_object *obj = NULL;
+  if(git_reference_dwim(&ref, repo, str) == GIT_OK){
+    if(git_reference_peel(&obj, ref, GIT_OBJECT_COMMIT) == GIT_OK){
+      git_reference_free(ref);
+      return obj;
+    }
+  }
+  if(git_revparse_single(&obj, repo, str) == GIT_OK){
+    return obj;
+  } else {
+    Rf_error("Failed to find ref '%s'", str);
+  }
+}
+
+git_commit *ref_to_commit(SEXP ref, git_repository *repo){
+  git_commit *commit = NULL;
+  git_object *revision = resolve_refish(ref, repo);
+  bail_if(git_commit_lookup(&commit, repo, git_object_id(revision)), "git_commit_lookup");
+  git_object_free(revision);
+  return commit;
+}
+
 SEXP safe_string(const char *x){
   return Rf_ScalarString(safe_char(x));
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -27,6 +27,10 @@ void bail_if_null(void * ptr, const char * what){
     bail_if(-1, what);
 }
 
+#ifndef GIT_OBJECT_COMMIT
+#define GIT_OBJECT_COMMIT GIT_OBJ_COMMIT
+#endif
+
 git_object * resolve_refish(SEXP string, git_repository *repo){
   if(!Rf_isString(string) || !Rf_length(string))
     Rf_error("Reference is not a string");
@@ -42,7 +46,7 @@ git_object * resolve_refish(SEXP string, git_repository *repo){
   if(git_revparse_single(&obj, repo, str) == GIT_OK){
     return obj;
   } else {
-    Rf_error("Failed to find ref '%s'", str);
+    Rf_error("Failed to find git reference '%s'", str);
   }
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -11,6 +11,8 @@ SEXP make_strvec(int n, ...);
 SEXP build_list(int n, ...);
 SEXP list_to_tibble(SEXP df);
 git_repository *get_git_repository(SEXP ptr);
+git_object *resolve_refish(SEXP string, git_repository *repo);
+git_commit *ref_to_commit(SEXP ref, git_repository *repo);
 
 #define build_tibble(...) list_to_tibble(build_list( __VA_ARGS__))
 


### PR DESCRIPTION
Fixes #87, fixes #43.

@jennybc this runs all of the `ref` strings through [git_reference_dwim](https://libgit2.org/libgit2/#HEAD/group/reference/git_reference_dwim) which should make it a bit smarter. I don't think there will be any breaking changes, but lmk if you notice any changes in how ref strings are interpreted.