### PR TITLE
Pass repo along in git_branch_set_upstream()

### DIFF
--- a/R/branch.R
+++ b/R/branch.R
@@ -85,7 +85,7 @@ git_branch_fast_forward <- function(ref, repo = '.'){
 git_branch_set_upstream <- function(upstream, branch = git_branch(repo), repo = '.'){
   repo <- git_open(repo)
   stopifnot(is.character(upstream))
-  if(!git_branch_exists(upstream, local = FALSE))
+  if(!git_branch_exists(upstream, local = FALSE, repo = repo))
     stop(sprintf("No remote branch found: %s, maybe fetch first?", upstream))
   .Call(R_git_branch_set_upstream, repo, upstream, branch)
   git_repo_path(repo)


### PR DESCRIPTION
Found because this bug breaks (dev) usethis. It's not something I have under automated tests, but it cropped up pretty fast in interactive use / manual tests.

Introduced in 40e7601c56983e46281f5a588207a2664851a1eb, I think.