### PR TITLE
Return merge state invisibly

### DIFF
--- a/R/merge.R
+++ b/R/merge.R
@@ -51,6 +51,7 @@ git_merge <- function(ref, commit = TRUE, squash = FALSE, repo = '.'){
   } else {
     stop(sprintf("State is '%s', not sure what to do", state))
   }
+  invisible(state)
 }
 
 #' @export


### PR DESCRIPTION
I don't think this PR is quite "done", because the results that currently return `"normal"` seem worth distinguishing. Specifically, when we haven't actually closed the deal, because of merge conflicts. Thoughts?

(This is motivated by usethis, but I won't count on this for v2.0.0.)

