### PR TITLE
Use cached gitcreds, if available

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Imports:
     rstudioapi (>= 0.11),
     zip (>= 2.1.0)
 Suggests:
+    gitcreds,
     spelling, 
     knitr,
     rmarkdown,

--- a/R/credentials.R
+++ b/R/credentials.R
@@ -48,6 +48,15 @@ make_cred_cb <- function(password = askpass, verbose = TRUE){
       if(nchar(github_pat) > 0 && grepl('^https?://([^/]*@)?github.com', url)){
         return(c("git", github_pat))
       }
+
+      # Try looking for (cached) gitcreds, mainly to support GHE
+      # This should never cause a prompt! It either returns creds or errors.
+      if(requireNamespace('gitcreds')){
+        creds <- tryCatch(gitcreds::gitcreds_get(url, set_cache = FALSE), error = function(e){})
+        if(length(creds) && length(creds$username)){
+          return(c(creds$username, creds$password))
+        }
+      }
     }
 
     # Retrieve a password from the credential manager

--- a/R/credentials.R
+++ b/R/credentials.R
@@ -51,7 +51,7 @@ make_cred_cb <- function(password = askpass, verbose = TRUE){
 
       # Try looking for (cached) gitcreds, mainly to support GHE
       # This should never cause a prompt! It either returns creds or errors.
-      if(requireNamespace('gitcreds')){
+      if(requireNamespace('gitcreds', quietly = TRUE)){
         creds <- tryCatch(gitcreds::gitcreds_get(url, set_cache = FALSE), error = function(e){})
         if(length(creds) && length(creds$username)){
           return(c(creds$username, creds$password))


### PR DESCRIPTION
To summarise: the status quo of https authentication in gert is:

  1. Try the `GITHUB_PAT` envvar if the host is `github.com`
  2. Otherwise, query the git credential store via credentials for a login for the given host (for example GHE).
  3. Otherwise prompt the user if possible.

With this PR, what we gain is:

  1. (b) If a `GITHUB_PAT_BERKELEY_EDU` var has been set by `gitcreds` and we are pushing to `BERKELY_EDU` we will try to use credentials from this variable. This saves us 1 call to the git credential store.



