### PR TITLE
Try to please rchk, attempt 2

### DIFF
--- a/src/branch.c
+++ b/src/branch.c
@@ -156,8 +156,10 @@ SEXP R_git_branch_list(SEXP ptr, SEXP local){
   }
   git_branch_iterator_free(iter);
   Rf_setAttrib(times, R_ClassSymbol, make_strvec(2, "POSIXct", "POSIXt"));
-  return build_tibble(6, "name", names, "local", islocal, "ref", refs,"upstream", upstreams,
+  SEXP out = build_tibble(6, "name", names, "local", islocal, "ref", refs,"upstream", upstreams,
                          "commit", ids, "updated", times);
+  UNPROTECT(6);
+  return out;
 }
 
 SEXP R_git_remote_list(SEXP ptr){
@@ -176,7 +178,9 @@ SEXP R_git_remote_list(SEXP ptr){
     }
     free(name);
   }
-  return build_tibble(2, "name", names, "url", url);
+  SEXP out = build_tibble(2, "name", names, "url", url);
+  UNPROTECT(2);
+  return out;
 }
 
 SEXP R_git_remote_add(SEXP ptr, SEXP name, SEXP url, SEXP refspec){
@@ -265,8 +269,10 @@ SEXP R_git_remote_refspecs(SEXP ptr, SEXP name){
     SET_STRING_ELT(dest, i, safe_char(git_refspec_dst(refspec)));
     LOGICAL(force)[i] = git_refspec_force(refspec);
   }
-  return build_tibble(7, "name", names, "url", urls, "direction", directions,
+  SEXP out = build_tibble(7, "name", names, "url", urls, "direction", directions,
                       "refspec", string, "src", src, "dest", dest, "force", force);
+  UNPROTECT(7);
+  return out;
 }
 
 SEXP R_git_remote_add_fetch(SEXP ptr, SEXP remote, SEXP refspec){
@@ -304,6 +310,7 @@ SEXP R_git_remote_info(SEXP ptr, SEXP name){
     "fetch", fetch,
     "push", push
   );
+  UNPROTECT(6);
   git_remote_free(remote);
   return out;
 }

--- a/src/clone.c
+++ b/src/clone.c
@@ -459,5 +459,7 @@ SEXP R_git_remote_ls(SEXP ptr, SEXP name, SEXP getkey, SEXP getcred, SEXP verbos
     SET_STRING_ELT(syms, i, safe_char(refs[i]->symref_target));
   }
   git_remote_free(remote);
-  return build_tibble(3, "ref", names, "symref", syms, "oid", oids);
+  SEXP out = build_tibble(3, "ref", names, "symref", syms, "oid", oids);
+  UNPROTECT(3);
+  return out;
 }

--- a/src/commit.c
+++ b/src/commit.c
@@ -67,7 +67,9 @@ static SEXP signature_data(git_signature *sig){
   Rf_setAttrib(time, R_ClassSymbol, make_strvec(2, "POSIXct", "POSIXt"));
   Rf_setAttrib(time, PROTECT(Rf_install("tz")), PROTECT(safe_string("UTC")));
   UNPROTECT(2);
-  return build_list(4, "name", name, "email", email, "time", time, "offset", offset);
+  SEXP out = build_list(4, "name", name, "email", email, "time", time, "offset", offset);
+  UNPROTECT(4);
+  return out;
 }
 
 SEXP R_git_signature_default(SEXP ptr){
@@ -193,8 +195,10 @@ SEXP R_git_commit_log(SEXP ptr, SEXP ref, SEXP max){
     head = commit;
   }
   Rf_setAttrib(times, R_ClassSymbol, make_strvec(2, "POSIXct", "POSIXt"));
-  return build_tibble(6, "commit", ids, "author", author, "time", times,
+  SEXP out = build_tibble(6, "commit", ids, "author", author, "time", times,
                       "files", files, "merge", merger, "message", msg);
+  UNPROTECT(6);
+  return out;
 }
 
 SEXP R_git_diff_list(SEXP ptr, SEXP ref){
@@ -231,7 +235,9 @@ SEXP R_git_diff_list(SEXP ptr, SEXP ref){
     }
   }
   git_diff_free(diff);
-  return build_tibble(4, "status", status, "old", oldfiles, "new", newfiles, "patch", patches);
+  SEXP out = build_tibble(4, "status", status, "old", oldfiles, "new", newfiles, "patch", patches);
+  UNPROTECT(4);
+  return out;
 }
 
 static SEXP get_parents(git_commit *commit){
@@ -255,8 +261,10 @@ SEXP R_git_commit_info(SEXP ptr, SEXP ref){
   SEXP diff = PROTECT(R_git_diff_list(ptr, ref));
   SEXP times = PROTECT(Rf_ScalarReal(git_commit_time(commit)));
   Rf_setAttrib(times, R_ClassSymbol, make_strvec(2, "POSIXct", "POSIXt"));
-  return build_list(7, "id", id, "parents", parents, "author", author, "committer", committer,
+  SEXP out = build_list(7, "id", id, "parents", parents, "author", author, "committer", committer,
                     "message", message, "time", times, "diff", diff);
+  UNPROTECT(7);
+  return out;
 }
 
 SEXP R_git_commit_descendant(SEXP ptr, SEXP ref, SEXP ancestor){

--- a/src/config.c
+++ b/src/config.c
@@ -62,7 +62,9 @@ SEXP R_git_config_list(SEXP ptr){
   }
   git_config_iterator_free(iter);
   git_config_free(cfg);
-  return build_tibble(3, "name", names, "value", values, "level", levels);
+  SEXP out = build_tibble(3, "name", names, "value", values, "level", levels);
+  UNPROTECT(3);
+  return out;
 }
 
 SEXP R_git_config_set(SEXP ptr, SEXP name, SEXP value){

--- a/src/conflicts.c
+++ b/src/conflicts.c
@@ -31,5 +31,7 @@ SEXP R_git_conflict_list(SEXP ptr){
     git_index_conflict_iterator_free(iter);
   }
   git_index_free(index);
-  return build_tibble(3, "ancestor", ancestor, "our", our, "their", their);
+  SEXP out = build_tibble(3, "ancestor", ancestor, "our", our, "their", their);
+  UNPROTECT(3);
+  return out;
 }

--- a/src/files.c
+++ b/src/files.c
@@ -51,8 +51,10 @@ SEXP R_git_repository_info(SEXP ptr){
     git_reference_free(head);
   }
 
-  return build_list(8, "path", path, "bare", bare, "head", headref, "shorthand", shorthand,
+  SEXP out = build_list(8, "path", path, "bare", bare, "head", headref, "shorthand", shorthand,
                     "commit", target, "remote", remote, "upstream", upstream, "reflist", refs);
+  UNPROTECT(8);
+  return out;
 }
 
 SEXP R_git_repository_path(SEXP ptr){
@@ -83,7 +85,9 @@ SEXP R_git_repository_ls(SEXP ptr){
   git_index_free(index);
   Rf_setAttrib(mtimes, R_ClassSymbol, make_strvec(2, "POSIXct", "POSIXt"));
   Rf_setAttrib(ctimes, R_ClassSymbol, make_strvec(2, "POSIXct", "POSIXt"));
-  return build_tibble(4, "path", paths, "filesize", sizes, "modified", mtimes, "created", ctimes);
+  SEXP out = build_tibble(4, "path", paths, "filesize", sizes, "modified", mtimes, "created", ctimes);
+  UNPROTECT(4);
+  return out;
 }
 
 SEXP R_git_repository_add(SEXP ptr, SEXP files, SEXP force){
@@ -188,5 +192,7 @@ SEXP R_git_status_list(SEXP ptr, SEXP show_staged){
     LOGICAL(staged)[i] = isstaged;
   }
   git_status_list_free(list);
-  return build_tibble(3, "file", files, "status", statuses, "staged", staged);
+  SEXP out = build_tibble(3, "file", files, "status", statuses, "staged", staged);
+  UNPROTECT(3);
+  return out;
 }

--- a/src/rebase.c
+++ b/src/rebase.c
@@ -65,7 +65,9 @@ SEXP R_git_rebase(SEXP ptr, SEXP upstream, SEXP commit_changes){
   }
   git_rebase_finish(rebase, NULL); //is no-op for in-memory rebase
   git_rebase_free(rebase);
-  return build_tibble(3, "commit", oids, "type", types, "conflicts", conflicts);
+  SEXP out = build_tibble(3, "commit", oids, "type", types, "conflicts", conflicts);
+  UNPROTECT(3);
+  return out;
 }
 
 static int count_changes(git_repository *repo){
@@ -127,9 +129,11 @@ SEXP R_git_ahead_behind(SEXP ptr, SEXP local, SEXP upstream){
   SEXP upstream_string = PROTECT(safe_string(git_oid_tostr_s(git_object_id(rev_upstream))));
   git_object_free(rev_local);
   git_object_free(rev_upstream);
-  return build_list(4,
+  SEXP out = build_list(4,
                     "ahead", PROTECT(Rf_ScalarInteger(ahead)),
                     "behind", PROTECT(Rf_ScalarInteger(behind)),
                     "local", local_string,
                     "upstream", upstream_string);
+  UNPROTECT(4);
+  return out;
 }

--- a/src/stash.c
+++ b/src/stash.c
@@ -54,6 +54,7 @@ SEXP R_git_stash_list(SEXP ptr){
   SEXP messages = PROTECT(Rf_allocVector(STRSXP, count));
   SEXP oidstr = PROTECT(Rf_allocVector(STRSXP, count));
   SEXP df = PROTECT(build_tibble(3, "index", indexes, "message", messages, "oid", oidstr));
+  UNPROTECT(3);
   if(count > 0)
     git_stash_foreach(repo, stash_ls_cb, df);
   UNPROTECT(1);

--- a/src/submodules.c
+++ b/src/submodules.c
@@ -37,6 +37,7 @@ SEXP R_git_submodule_list(SEXP ptr){
                          "url", PROTECT(Rf_allocVector(STRSXP, n)),
                          "branch", PROTECT(Rf_allocVector(STRSXP, n)),
                          "head", PROTECT(Rf_allocVector(STRSXP, n))));
+  UNPROTECT(5);
   git_submodule_foreach(repo, submodule_fill, df);
   UNPROTECT(1);
   return df;
@@ -52,6 +53,7 @@ SEXP R_git_submodule_info(SEXP ptr, SEXP name){
                         "url", PROTECT(safe_string(git_submodule_url(sm))),
                         "branch", PROTECT(safe_string(git_submodule_branch(sm))),
                         "head", PROTECT(safe_string(git_oid_tostr_s(git_submodule_head_id(sm)))));
+  UNPROTECT(5);
   git_submodule_free(sm);
   return out;
 }

--- a/src/tag.c
+++ b/src/tag.c
@@ -18,7 +18,9 @@ SEXP R_git_tag_list(SEXP ptr, SEXP pattern){
       SET_STRING_ELT(ids, i, safe_char(git_oid_tostr_s(&oid)));
   }
   git_strarray_free(&tag_list);
-  return build_tibble(3, "name", names, "ref", refs, "commit", ids);
+  SEXP out = build_tibble(3, "name", names, "ref", refs, "commit", ids);
+  UNPROTECT(3);
+  return out;
 }
 
 SEXP R_git_tag_create(SEXP ptr, SEXP name, SEXP message, SEXP ref){

--- a/src/utils.c
+++ b/src/utils.c
@@ -108,7 +108,7 @@ SEXP build_list(int n, ...){
   }
   va_end(args);
   Rf_setAttrib(vec, R_NamesSymbol, names);
-  UNPROTECT(2 + n);
+  UNPROTECT(2);
   return vec;
 }
 

--- a/src/version.c
+++ b/src/version.c
@@ -35,7 +35,9 @@ SEXP R_libgit2_config(){
   git_libgit2_opts(GIT_OPT_GET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL, &buf);
   SEXP config_search_path = PROTECT(Rf_ScalarString(Rf_mkCharLen(buf.ptr, buf.size)));
   git_buf_free(&buf);
-  return build_list(7, "version", version, "ssh", ssh, "https", https, "threads", threads,
+  SEXP out = build_list(7, "version", version, "ssh", ssh, "https", https, "threads", threads,
                     "config.global", config_global, "config.system", config_system,
                     "config.home", config_search_path);
+  UNPROTECT(7);
+  return out;
 }


### PR DESCRIPTION
Not super happy with this, but rchk now enforces that each internal function is "balanced" which means that it has to PROTECT as many as it UNPROTECTs. So we can no longer unprotect from inside the `build_list` utility function.