### PR TITLE
Adding shebang

### DIFF
--- a/configure
+++ b/configure
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Anticonf (tm) script by Jeroen Ooms (2020)
 # This script will query 'pkg-config' for the required cflags and ldflags.
 # On MacOS and Linux, if libgit2 is not found or too old, we try to downoad


### PR DESCRIPTION
I had the same issue as reported [here](https://github.com/jeroen/curl/pull/239) by me also, missing a shebang notation breaks Docker builds in Alpine based images.