### PR TITLE
Windows: update to libgit2 1.7.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gert
 Title: Simple Git Client for R
-Version: 1.9.3
+Version: 1.9000
 Authors@R: c(
     person("Jeroen", "Ooms", role = c("aut", "cre"), email = "jeroen@berkeley.edu",
       comment = c(ORCID = "0000-0002-4035-0289")),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+2.0.0
+  - Windows: update to libgit2 version 1.7.0
+
 1.9.3
   - Add git_commit_stats() function
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,4 @@
-VERSION = 1.4.2-fixed
+VERSION = 1.7.0
 RWINLIB = ../windows/libgit2-$(VERSION)
 TARGET = lib$(subst gcc,,$(COMPILED_BY))$(R_ARCH)
 

--- a/src/clone.c
+++ b/src/clone.c
@@ -2,7 +2,9 @@
 #define _GNU_SOURCE 1
 #endif
 
-#if defined(__sun)
+/* Beginning in libgit2 v1.4.5 and v1.5.1, libgit2 will now perform host key checking by default.
+ * However on Windows libssh does not have access to the cert store */
+#if defined(__sun) || defined(_WIN32)
 #define SKIP_CERTIFICATE_CHECK
 #endif
 


### PR DESCRIPTION
libgit2 1.7.0 has a few breaking changes and we also enabled threading in the build, so be careful for regressions.

See: https://github.com/libgit2/libgit2/pull/6349