### PR TITLE
Fix: git_ls with a ref gives correct details

### DIFF
--- a/src/files.c
+++ b/src/files.c
@@ -67,6 +67,7 @@ SEXP R_git_repository_path(SEXP ptr){
 SEXP R_git_repository_ls(SEXP ptr, SEXP ref){
   git_index *index = NULL;
   git_repository *repo = get_git_repository(ptr);
+  bail_if(git_repository_index(&index, repo), "git_repository_index");
   if(Rf_length(ref) && Rf_isString(ref)){
     git_object *revision = resolve_refish(ref, repo);
     git_commit *commit = NULL;
@@ -74,12 +75,9 @@ SEXP R_git_repository_ls(SEXP ptr, SEXP ref){
     bail_if(git_commit_lookup(&commit, repo, git_object_id(revision)), "git_commit_lookup");
     git_object_free(revision);
     bail_if(git_commit_tree(&tree, commit), "git_commit_tree");
-    bail_if(git_index_new(&index), "git_index_new");
     bail_if(git_index_read_tree(index, tree), "git_index_read_tree");
     git_commit_free(commit);
     git_tree_free(tree);
-  } else {
-    bail_if(git_repository_index(&index, repo), "git_repository_index");
   }
 
   size_t entry_count = git_index_entrycount(index);

--- a/tests/testthat/test-commit.R
+++ b/tests/testthat/test-commit.R
@@ -61,6 +61,19 @@ test_that("creating a commit", {
   expect_equal(log$time[1], timestamp)
 })
 
+test_that("Passing ref into git_ls gives correct info", {
+  t <- tempfile()
+  dir.create(t)
+  writeLines(c("# Example", "", "example repo"), file.path(t, "README.md"))
+  git_init(t)
+  git_add(".", repo = t)
+  user <- "author <author@example.com>"
+  sha <- git_commit("initial", author = user, committer = user, repo = t)
+  without_ref <- git_ls(repo = t)
+  with_ref <- git_ls(repo = t, ref = "HEAD")
+  expect_equal(with_ref, without_ref)
+})
+
 test_that("creating a commit in another directory without author works", {
   path <- tempfile("gert-tests-commit")
   on.exit(unlink(path, recursive = TRUE))


### PR DESCRIPTION
This PR addresses https://github.com/r-lib/gert/issues/211. `git_index_new`, which was being used when `git_ls` had a ref, is not in the current version of libgit2 (only until v1.6.5) so we get the index via `git_repository_index`.

I have also added the test contained in the issue.