### PR TITLE
Fix incorrect pointer argument to git_commit_create

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -113,13 +113,13 @@ SEXP R_git_signature_parse(SEXP x){
   return signature_data(parse_signature(x));
 }
 
-static void free_commit_list(const git_commit **list, int len){
+static void free_commit_list(git_commit **list, int len){
   for(int i = 0; i < len; i++){
     git_commit_free((git_commit*) list[i]);
   }
 }
 
-static int create_commit_list(const git_commit **list, git_repository *repo, SEXP merge_parents){
+static int create_commit_list(git_commit **list, git_repository *repo, SEXP merge_parents){
   git_commit *commit = NULL;
   git_reference *head = NULL;
   int err = git_repository_head(&head, repo);
@@ -151,7 +151,7 @@ SEXP R_git_commit_create(SEXP ptr, SEXP message, SEXP author, SEXP committer,
   git_signature *commitsig = parse_signature(committer);
   bail_if(git_message_prettify(&msg, Rf_translateCharUTF8(STRING_ELT(message, 0)), 0, 0),
           "git_message_prettify");
-  const git_commit *parents[10] = {0};
+  git_commit *parents[10] = {0};
   int number_parents = create_commit_list(parents, repo, merge_parents);
 
   // Setup tree, see: https://libgit2.org/docs/examples/init/

--- a/src/rebase.c
+++ b/src/rebase.c
@@ -102,7 +102,7 @@ SEXP R_git_cherry_pick(SEXP ptr, SEXP commit_id){
   git_reference *head = NULL;
   bail_if(git_repository_head(&head, repo), "git_repository_head");
   bail_if(git_commit_lookup(&parent, repo, git_reference_target(head)), "git_commit_lookup");
-  const git_commit *parents[1] = {parent}; // This ignores (aka squashes) other parents from a merge-commit
+  git_commit *parents[1] = {parent}; // This ignores (aka squashes) other parents from a merge-commit
   bail_if(git_repository_index(&index, repo), "git_repository_index");
   bail_if(git_index_write_tree(&tree_id, index), "git_index_write_tree");
   bail_if(git_tree_lookup(&tree, repo, &tree_id), "git_tree_lookup");


### PR DESCRIPTION
This should fix  #213 where the latest version of gcc fails because libgit2 expects a pointer of type `git_commit * const []` to `git_commit_create`.