### PR TITLE
Workaround for accidental API change in libgit2 1.8.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gert
 Title: Simple Git Client for R
-Version: 2.0.1
+Version: 2.0.2
 Authors@R: c(
     person("Jeroen", "Ooms", role = c("aut", "cre"), email = "jeroen@berkeley.edu",
       comment = c(ORCID = "0000-0002-4035-0289")),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+2.0.2
+  - Workaround for accidental API change in libgit2 1.8.0
+
 2.0.1
   - Fix a printf warning for cran
 

--- a/src/commit.c
+++ b/src/commit.c
@@ -159,7 +159,7 @@ SEXP R_git_commit_create(SEXP ptr, SEXP message, SEXP author, SEXP committer,
   bail_if(git_index_write_tree(&tree_id, index), "git_index_write_tree");
   bail_if(git_tree_lookup(&tree, repo, &tree_id), "git_tree_lookup");
   bail_if(git_commit_create(&commit_id, repo, "HEAD", authsig, commitsig, "UTF-8",
-                            msg.ptr, tree, number_parents, parents), "git_commit_create");
+                            msg.ptr, tree, number_parents, no_const_workaround parents), "git_commit_create");
   if(number_parents > 1)
     bail_if(git_repository_state_cleanup(repo), "git_repository_state_cleanup");
   free_commit_list(parents, number_parents);

--- a/src/rebase.c
+++ b/src/rebase.c
@@ -108,7 +108,7 @@ SEXP R_git_cherry_pick(SEXP ptr, SEXP commit_id){
   bail_if(git_tree_lookup(&tree, repo, &tree_id), "git_tree_lookup");
   bail_if(git_commit_create(&new_oid, repo, "HEAD", git_commit_author(orig),
                             git_commit_committer(orig), git_commit_message_encoding(orig),
-                            git_commit_message(orig), tree, 1, parents), "git_commit_create");
+                            git_commit_message(orig), tree, 1, no_const_workaround parents), "git_commit_create");
   bail_if(git_repository_state_cleanup(repo), "git_repository_state_cleanup");
   git_reference_free(head);
   git_commit_free(parent);

--- a/src/utils.h
+++ b/src/utils.h
@@ -23,4 +23,11 @@ git_commit *ref_to_commit(SEXP ref, git_repository *repo);
 
 #define AT_LEAST_LIBGIT2(x,y) (LIBGIT2_VER_MAJOR > x || LIBGIT2_VER_MINOR >= y)
 
+/* See: https://github.com/libgit2/libgit2/issues/6793 */
+#if AT_LEAST_LIBGIT2(1,8)
+#define no_const_workaround (git_commit **)
+#else
+#define no_const_workaround
+#endif
+
 void set_checkout_notify_cb(git_checkout_options *opts);


### PR DESCRIPTION
Workaround for issue described here: https://github.com/libgit2/libgit2/issues/6793