### PR TITLE
fix: make git_cherry_pick() accept a shortened hash

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,9 +18,9 @@ jobs:
         config:
           - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
+          - {os: windows-latest, r: '4.3'}
           - {os: windows-latest, r: '4.2'}
           - {os: windows-latest, r: '4.1'}
-          - {os: windows-latest, r: '3.6'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}

--- a/R/rebase.R
+++ b/R/rebase.R
@@ -83,9 +83,6 @@ git_reset <- function(type = c("soft", "hard", "mixed"), ref = "HEAD", repo = ".
 #' @useDynLib gert R_git_cherry_pick
 #' @param commit id of the commit to cherry pick
 git_cherry_pick <- function(commit, repo = '.'){
-  if (!is_full_hash(commit)) {
-    commit <- git_commit_info(commit, repo = repo)$id
-  }
   repo <- git_open(repo)
   assert_string(commit)
   .Call(R_git_cherry_pick, repo, commit)

--- a/R/rebase.R
+++ b/R/rebase.R
@@ -83,6 +83,9 @@ git_reset <- function(type = c("soft", "hard", "mixed"), ref = "HEAD", repo = ".
 #' @useDynLib gert R_git_cherry_pick
 #' @param commit id of the commit to cherry pick
 git_cherry_pick <- function(commit, repo = '.'){
+  if (!is_full_hash(commit)) {
+    commit <- git_commit_info(commit, repo = repo)$id
+  }
   repo <- git_open(repo)
   assert_string(commit)
   .Call(R_git_cherry_pick, repo, commit)

--- a/src/rebase.c
+++ b/src/rebase.c
@@ -81,7 +81,6 @@ static int count_changes(git_repository *repo){
 }
 
 SEXP R_git_cherry_pick(SEXP ptr, SEXP commit_id){
-  git_oid oid = {{0}};
   git_oid tree_id = {{0}};
   git_tree *tree = NULL;
   git_index *index = NULL;
@@ -89,8 +88,8 @@ SEXP R_git_cherry_pick(SEXP ptr, SEXP commit_id){
   git_repository *repo = get_git_repository(ptr);
   git_cherrypick_options opt = GIT_CHERRYPICK_OPTIONS_INIT;
   opt.merge_opts.flags = GIT_MERGE_FAIL_ON_CONFLICT;
-  bail_if(git_oid_fromstr(&oid, CHAR(STRING_ELT(commit_id, 0))), "git_oid_fromstr");
-  bail_if(git_commit_lookup(&orig, repo, &oid), "git_commit_lookup");
+  git_object *revision = resolve_refish(commit_id, repo);
+  bail_if(git_commit_lookup(&orig, repo, git_object_id(revision)), "git_commit_lookup");
   bail_if(git_cherrypick(repo, orig, &opt), "git_cherrypick");
   bail_if(git_repository_state_cleanup(repo), "git_repository_state_cleanup");
   git_oid new_oid = {{0}};
@@ -110,6 +109,7 @@ SEXP R_git_cherry_pick(SEXP ptr, SEXP commit_id){
                             git_commit_committer(orig), git_commit_message_encoding(orig),
                             git_commit_message(orig), tree, 1, no_const_workaround parents), "git_commit_create");
   bail_if(git_repository_state_cleanup(repo), "git_repository_state_cleanup");
+  git_object_free(revision);
   git_reference_free(head);
   git_commit_free(parent);
   git_index_free(index);

--- a/tests/testthat/test-rebase.R
+++ b/tests/testthat/test-rebase.R
@@ -65,6 +65,11 @@ test_that("rebasing things", {
 })
 
 test_that("cherry-picking things", {
+  if(!user_is_configured()){
+    git_config_set("user.name", "Jerry")
+    git_config_set("user.email", "jerry@gmail.com")
+  }
+
   repo <- file.path(tempdir(), 'gert')
   if(!file.exists(repo)) git_clone('https://github.com/r-lib/gert', path = repo)
   git_branch_create('backup', checkout = FALSE, repo = repo)

--- a/tests/testthat/test-rebase.R
+++ b/tests/testthat/test-rebase.R
@@ -63,3 +63,24 @@ test_that("rebasing things", {
   git_reset_hard("HEAD^", repo = repo)
   git_branch_delete('backup', repo = repo)
 })
+
+test_that("cherry-picking things", {
+  repo <- file.path(tempdir(), 'gert')
+  if(!file.exists(repo)) git_clone('https://github.com/r-lib/gert', path = repo)
+  git_branch_create('backup', checkout = FALSE, repo = repo)
+
+  write.csv(iris, file.path(repo, 'iris.csv'))
+  git_add('iris.csv', repo = repo)
+  commit <- git_commit("Added iris.csv file", repo = repo)
+
+  git_branch_checkout('backup', repo = repo)
+
+  # full ID
+  expect_type(git_cherry_pick(commit, repo = repo), "character")
+
+  git_reset_hard("HEAD^", repo = repo)
+
+  # shortened ID
+  short_commit <- substr(commit, 1, 7)
+  expect_type(git_cherry_pick(short_commit, repo = repo), "character")
+})

--- a/tests/testthat/test-rebase.R
+++ b/tests/testthat/test-rebase.R
@@ -80,7 +80,7 @@ test_that("cherry-picking things", {
 
   # Cherry pick the commit onto main
   git_branch_checkout(mainbranch, repo = repo)
-  expect_equal(gert::git_log(repo=repo)$commit, first_commit)
+  expect_equal(git_log(repo=repo)$commit, first_commit)
   short_commit <- substr(commit, 1, 7)
   expect_equal(git_cherry_pick(short_commit, repo = repo), commit)
   expect_length(git_log(repo = repo)$commit, 2)

--- a/tests/testthat/test-rebase.R
+++ b/tests/testthat/test-rebase.R
@@ -65,18 +65,13 @@ test_that("rebasing things", {
 })
 
 test_that("cherry-picking things", {
-  if(!user_is_configured()){
-    git_config_set("user.name", "Jerry")
-    git_config_set("user.email", "jerry@gmail.com")
-  }
-
   repo <- file.path(tempdir(), 'gert')
   if(!file.exists(repo)) git_clone('https://github.com/r-lib/gert', path = repo)
   git_branch_create('backup', checkout = FALSE, repo = repo)
 
   write.csv(iris, file.path(repo, 'iris.csv'))
   git_add('iris.csv', repo = repo)
-  commit <- git_commit("Added iris.csv file", repo = repo)
+  commit <- git_commit("Added iris.csv file", author = "maelle <maelle@salmon.fish>", repo = repo)
 
   git_branch_checkout('backup', repo = repo)
 


### PR DESCRIPTION
I tried using `resolve_refish(ref, repo)` in rebase.c but I got stuck because I wasn't able to create a thing of the right type for this line:

https://github.com/r-lib/gert/blob/d0fc50f033dda9e8f9634d20fe47462cb188f40b/src/rebase.c#L92

I'd be curious to see how to actually solve this on the C side.

