### PR TITLE
fix typos

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -40,7 +40,7 @@
 
 1.7.0
   - git_status() gains parameter pathspec
-  - git_ls() gains paremeter 'ref' and works with bare repositories
+  - git_ls() gains parameter 'ref' and works with bare repositories
 
 1.6.0
   - We recommend at least libgit2 1.0 now
@@ -75,7 +75,7 @@
 
 1.3.1
   - Windows: fix build for ucrt toolchains
-  - Solaris: disable https cert verfication
+  - Solaris: disable https cert verification
 
 1.3.0
   - Some encoding fixes for latin1 paths, especially non-ascii Windows usernames.

--- a/configure
+++ b/configure
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Anticonf (tm) script by Jeroen Ooms (2022)
 # This script will query 'pkg-config' for the required cflags and ldflags.
-# On MacOS and Linux, if libgit2 is not found or too old, we try to downoad
+# On MacOS and Linux, if libgit2 is not found or too old, we try to download
 # a portable static build and use that instead.
 
 # Library settings

--- a/src/clone.c
+++ b/src/clone.c
@@ -226,7 +226,7 @@ static int auth_callback(git_cred **cred, const char *url, const char *username,
   /* This is for HTTP remotes */
   if(allowed_types & GIT_CREDTYPE_USERPASS_PLAINTEXT){
     if(cb_data->retries > 3){
-      print_if_verbose("Failed password authentiation %d times. Giving up\n", cb_data->retries - 1);
+      print_if_verbose("Failed password authentication %d times. Giving up\n", cb_data->retries - 1);
       cb_data->retries = 0;
     } else {
       cb_data->retries++;


### PR DESCRIPTION
purposely unattended to

```
$ grep -nr chsange gert
gert/R/rebase.R:57:#' * `git_reset_soft()` uncommits changes, but keeps the chsange uncommited
gert/man/git_reset.Rd:28:\item \code{git_reset_soft()} uncommits changes, but keeps the chsange uncommited
$ 
```

<hr>

in `#237` the decription of the various resets was rewritten