### PR TITLE
Add force arg to git branch create

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gert
 Title: Simple Git Client for R
-Version: 2.1.2
+Version: 2.1.3
 Authors@R: c(
     person("Jeroen", "Ooms", role = c("aut", "cre"), email = "jeroenooms@gmail.com",
       comment = c(ORCID = "0000-0002-4035-0289")),

--- a/R/branch.R
+++ b/R/branch.R
@@ -58,12 +58,14 @@ git_branch_checkout <- function(branch, force = FALSE, orphan = FALSE, repo = '.
 #' @useDynLib gert R_git_create_branch
 #' @param ref string with a branch/tag/commit
 #' @param checkout move HEAD to the newly created branch
-git_branch_create <- function(branch, ref = "HEAD", checkout = TRUE, repo = '.'){
+#' @param force overwrite existing branch
+git_branch_create <- function(branch, ref = "HEAD", checkout = TRUE, force = FALSE, repo = '.'){
   repo <- git_open(repo)
   branch <- as.character(branch)
   ref <- as.character(ref)
   checkout <- as.logical(checkout)
-  invisible(.Call(R_git_create_branch, repo, branch, ref, checkout))
+  force <- as.logical(force)
+  invisible(.Call(R_git_create_branch, repo, branch, ref, checkout, force))
 }
 
 #' @export

--- a/man/git_branch.Rd
+++ b/man/git_branch.Rd
@@ -18,7 +18,13 @@ git_branch_list(local = NULL, repo = ".")
 
 git_branch_checkout(branch, force = FALSE, orphan = FALSE, repo = ".")
 
-git_branch_create(branch, ref = "HEAD", checkout = TRUE, repo = ".")
+git_branch_create(
+  branch,
+  ref = "HEAD",
+  checkout = TRUE,
+  force = FALSE,
+  repo = "."
+)
 
 git_branch_delete(branch, repo = ".")
 
@@ -42,7 +48,7 @@ branches. Use NULL to return all branches.}
 
 \item{branch}{name of branch to check out}
 
-\item{force}{ignore conflicts and overwrite modified files}
+\item{force}{overwrite existing branch}
 
 \item{orphan}{if branch does not exist, checkout unborn branch}
 

--- a/src/branch.c
+++ b/src/branch.c
@@ -43,7 +43,7 @@ SEXP R_git_branch_exists(SEXP ptr, SEXP name, SEXP local){
   return Rf_ScalarLogical(branch_exists(repo, CHAR(STRING_ELT(name, 0)), r_branch_type(local)));
 }
 
-SEXP R_git_create_branch(SEXP ptr, SEXP name, SEXP ref, SEXP checkout){
+SEXP R_git_create_branch(SEXP ptr, SEXP name, SEXP ref, SEXP checkout, SEXP force){
   git_object *obj;
   git_commit *commit = NULL;
   git_reference *branch = NULL;
@@ -55,7 +55,7 @@ SEXP R_git_create_branch(SEXP ptr, SEXP name, SEXP ref, SEXP checkout){
   git_object *revision = resolve_refish(ref, repo);
   bail_if(git_commit_lookup(&commit, repo, git_object_id(revision)), "git_commit_lookup");
   git_object_free(revision);
-  bail_if(git_branch_create(&branch, repo, CHAR(STRING_ELT(name, 0)), commit, 0), "git_branch_create");
+  bail_if(git_branch_create(&branch, repo, CHAR(STRING_ELT(name, 0)), commit, Rf_asInteger(force)), "git_branch_create");
   git_commit_free(commit);
   if(branch_exists(repo, source, GIT_BRANCH_REMOTE)){
     bail_if(git_branch_set_upstream(branch, source), "git_branch_set_upstream");

--- a/src/init.c
+++ b/src/init.c
@@ -32,7 +32,7 @@ extern SEXP R_git_commit_stats(SEXP, SEXP);
 extern SEXP R_git_config_list(SEXP);
 extern SEXP R_git_config_set(SEXP, SEXP, SEXP);
 extern SEXP R_git_conflict_list(SEXP);
-extern SEXP R_git_create_branch(SEXP, SEXP, SEXP, SEXP);
+extern SEXP R_git_create_branch(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP R_git_delete_branch(SEXP, SEXP);
 extern SEXP R_git_diff_list(SEXP, SEXP);
 extern SEXP R_git_ignore_path_is_ignored(SEXP ptr, SEXP path);
@@ -106,7 +106,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"R_git_config_list",         (DL_FUNC) &R_git_config_list,         1},
   {"R_git_config_set",          (DL_FUNC) &R_git_config_set,          3},
   {"R_git_conflict_list",       (DL_FUNC) &R_git_conflict_list,       1},
-  {"R_git_create_branch",       (DL_FUNC) &R_git_create_branch,       4},
+  {"R_git_create_branch",       (DL_FUNC) &R_git_create_branch,       5},
   {"R_git_delete_branch",       (DL_FUNC) &R_git_delete_branch,       2},
   {"R_git_diff_list",           (DL_FUNC) &R_git_diff_list,           2},
   {"R_git_ignore_path_is_ignored", (DL_FUNC) &R_git_ignore_path_is_ignored, 2},


### PR DESCRIPTION
Resolves #238. This adds an optional force arg to `git_branch_create` to allow for overwriting of existing branches