### PR TITLE
remove old test for ancient windows server

### DIFF
--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -7,8 +7,6 @@ test_that("public ssh remotes with random key", {
   expect_true(file.exists(file.path(target, 'DESCRIPTION')))
 })
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && isTRUE(grepl('Windows Server 2008', osVersion))
-
 # Even for public repos, Github only allows keys that it knows.
 test_that("private ssh remotes with key", {
   skip_if_offline('github.com') #Also skips on_cran
@@ -49,13 +47,9 @@ test_that("HTTP user/pass auth", {
                             rawToChar(dec)), path = target3)
   expect_true(file.exists(file.path(target3, 'hello')))
 
-
-  # This seems to fail on WinBuilder due to some syscall
-  if(!isTRUE(isOldWindows)){
-    # Test that repo is private
-    expect_error(git_clone('https://github.com/jeroenooms/testprivate',
-                           password = "bla", path = tempfile()), 'Authentication', class = 'GIT_EAUTH')
-  }
+  # Test that repo is private
+  expect_error(git_clone('https://github.com/jeroenooms/testprivate',
+                         password = "bla", path = tempfile()), 'Authentication', class = 'GIT_EAUTH')
 
   # Test with PAT
   Sys.setenv(GITHUB_PAT = rawToChar(dec))

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -7,7 +7,7 @@ test_that("public ssh remotes with random key", {
   expect_true(file.exists(file.path(target, 'DESCRIPTION')))
 })
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
+isOldWindows <- Sys.info()[["sysname"]] == "Windows" && isTRUE(grepl('Windows Server 2008', osVersion))
 
 # Even for public repos, Github only allows keys that it knows.
 test_that("private ssh remotes with key", {


### PR DESCRIPTION
originally caught attention as a piece of code subject to some edge case behavior where `osVersion` can be `NULL` (`?osVersion`). That would break `&&logical()`, assuming it's possible to get `is.null(osVersion)` on `sysname=="Windows"` systems (I have not experienced this).