### PR TITLE
`git_checkout_pull_request()`: pass repo arg to `git_branch_exists()`

### DIFF
--- a/R/pr.R
+++ b/R/pr.R
@@ -17,7 +17,7 @@ git_checkout_pull_request <- function(pr = 1, remote = NULL, repo = '.'){
   local_branch <- sprintf("pr/%s", pr)
   remote_branch <- sprintf("%s/pr/%s", remote, pr)
   git_fetch_pull_requests(pr = pr, remote = remote, repo = repo)
-  if(git_branch_exists(local_branch)){
+  if(git_branch_exists(local_branch, repo = repo)){
     inform("Continuing on existing pr branch: %s", local_branch)
     git_branch_checkout(local_branch, repo = repo)
     git_pull(repo = repo)


### PR DESCRIPTION
I noticed a bug when attempting to check out a pull request programmatically in a repo in a temporary directory. It turned out that the repo argument was not being passed to `git_branch_exists`. The workaround at the moment, is to run this code in the git directory.

``` r
print(tmp <- tempfile())
#> [1] "/var/folders/t2/chsckzh12t38xqwg17xslwr80000gn/T//RtmpCfmpAw/file888d6ffbc3dc"
print(getwd())
#> [1] "/private/var/folders/t2/chsckzh12t38xqwg17xslwr80000gn/T/Rtmpys1Ric/reprex-82ee7ec139de-fussy-agama"
gert::git_clone("https://github.com/r-lib/gert.git", tmp)
gert::git_checkout_pull_request(pr = 227, repo = tmp)
#> Error in libgit2::git_repository_open_ext: could not find repository at '/private/var/folders/t2/chsckzh12t38xqwg17xslwr80000gn/T/Rtmpys1Ric/reprex-82ee7ec139de-fussy-agama'
withr::with_dir(tmp, {
  gert::git_checkout_pull_request(pr = 227)
})
#> Creating new branch: pr/227
```

<sup>Created on 2025-07-23 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>