### PR TITLE
if no remote upstream, return remote address if single; fixes #131

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # gert (development version)
 
+- Fix `git_info()` for the case when no upstream is configured (@mpage, #263)
 - Improve manual pages (@olivroy, #227)
 - Fix badge links in `README.md` (@dpprdan, #189)
 - Use `NEWS.md` instead of `NEWS` (@olivroy, #209)

--- a/src/files.c
+++ b/src/files.c
@@ -41,6 +41,14 @@ SEXP R_git_repository_info(SEXP ptr){
     git_reference_free(head);
   }
 
+  /* If remote still NA (no upstream configured), use sole remote if exactly one */
+  if(STRING_ELT(remote, 0) == NA_STRING){
+    git_strarray remotes = {0};
+    if(git_remote_list(&remotes, repo) == 0 && remotes.count == 1)
+      SET_STRING_ELT(remote, 0, safe_char(remotes.strings[0]));
+    git_strarray_free(&remotes);
+  }
+
   SEXP out = build_list(8, "path", path, "bare", bare, "head", headref, "shorthand", shorthand,
                     "commit", target, "remote", remote, "upstream", upstream, "reflist", refs);
   UNPROTECT(8);

--- a/tests/testthat/test-remotes.R
+++ b/tests/testthat/test-remotes.R
@@ -6,12 +6,12 @@ test_that("remotes from new repo", {
   expect_error(git_remote_info(repo = repo))
   expect_error(git_remote_refspecs(repo = repo))
   expect_error(git_remote_set_url('https://github.com/foo/bar', repo = repo))
-  expect_error(git_remote_info(repo = repo))
+  expect_error(git_remote_info(repo = repo), "remote 'NA' does not exist")
   expect_error(git_remote_set_pushurl(
     'https://github.com/foo/bar',
     repo = repo
   ))
-  expect_error(git_remote_info(repo = repo))
+  expect_error(git_remote_info(repo = repo), "remote 'NA' does not exist")
   expect_equal(
     git_remote_add(
       'https://github.com/jeroen/webp',

--- a/tests/testthat/test-remotes.R
+++ b/tests/testthat/test-remotes.R
@@ -6,10 +6,12 @@ test_that("remotes from new repo", {
   expect_error(git_remote_info(repo = repo))
   expect_error(git_remote_refspecs(repo = repo))
   expect_error(git_remote_set_url('https://github.com/foo/bar', repo = repo))
+  expect_error(git_remote_info(repo = repo))
   expect_error(git_remote_set_pushurl(
     'https://github.com/foo/bar',
     repo = repo
   ))
+  expect_error(git_remote_info(repo = repo))
   expect_equal(
     git_remote_add(
       'https://github.com/jeroen/webp',
@@ -18,6 +20,9 @@ test_that("remotes from new repo", {
     ),
     'jeroen'
   )
+  # info should work even when no upstream:
+  info <- git_remote_info(repo = repo)
+  expect_equal(info$url, "https://github.com/jeroen/webp")
   git_fetch('jeroen', 'master', repo = repo)
   git_branch_create('master', 'jeroen/master', repo = repo)
   git_branch_create(


### PR DESCRIPTION
Here's a reprex to show the problem:
``` r
library(gert)
#> Linking to libgit2 v1.9.2, ssh support: YES
#> Global config: ~/.gitconfig
#> Default user: me
path <- file.path(tempdir(), "test")
git_init(path = path)
git_remote_add(url = "https://codeberg.org/mpadge/repo", name = "newremote", repo = path)
```
Then note that `git_info()` returns `NA` for `remote`:
``` r
git_info(repo = path)
#> $path
#> [1] "/tmp/RtmpMdEIbU/test/"
#> 
#> $bare
#> [1] FALSE
#> 
#> $head
#> [1] NA
#> 
#> $shorthand
#> [1] NA
#> 
#> $commit
#> [1] NA
#> 
#> $remote
#> [1] NA
#> 
#> $upstream
#> [1] NA
#> 
#> $reflist
#> character(0)
```
And that makes this fail, even though I've explicitly set a `remote`:
``` r
git_remote_info (repo = path)
#> Error:
#> ! remote 'NA' does not exist
```

There is a _remote_, just no upstream head. This PR fixes that by setting a `remote` value from `git_info` when there is no upstream, but a single remote URL. That then gives this:
``` r
library(gert)
#> Linking to libgit2 v1.9.2, ssh support: YES
#> Global config: ~/.gitconfig
#> Default user: me

git_info(repo = path) # Remote now listed!
#> $path
#> [1] "/tmp/RtmpMdEIbU/test/"
#> 
#> $bare
#> [1] FALSE
#> 
#> $head
#> [1] NA
#> 
#> $shorthand
#> [1] NA
#> 
#> $commit
#> [1] NA
#> 
#> $remote
#> [1] "newremote"
#> 
#> $upstream
#> [1] NA
#> 
#> $reflist
#> character(0)
```
And because there is now a remote, this works:
``` r
git_remote_info (repo = path)
#> $name
#> [1] "newremote"
#> 
#> $url
#> [1] "https://codeberg.org/mpadge/repo"
#> 
#> $push_url
#> NULL
#> 
#> $head
#> NULL
#> 
#> $fetch
#> [1] "+refs/heads/*:refs/remotes/newremote/*"
#> 
#> $push
#> character(0)
```

<sup>Created on 2026-03-09 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>